### PR TITLE
minor makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 #---------------------------------------------------------------------------------
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@python build_headers.py "$(FIRM_INFO)"
+	@py -2 build_headers.py "$(FIRM_INFO)"
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 	@cp $(TARGET).nds boot.nds
  

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
 	@python build_headers.py "$(FIRM_INFO)"
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
-	@cp b9sTool.nds boot.nds
+	@cp $(TARGET).nds boot.nds
  
 #---------------------------------------------------------------------------------
 clean:


### PR DESCRIPTION
ensure `build_headers.py` will run in python 2
ensure making `boot.nds` will work regardless of curdir name